### PR TITLE
improve sitting

### DIFF
--- a/extension/十周年UI/decadeLayout.css
+++ b/extension/十周年UI/decadeLayout.css
@@ -80,12 +80,12 @@
 /*8人座, 3 player in center*/
 #arena[data-layout='nova'][data-number='8']>.player[data-position='1'] {
     left: auto;
-    top: 45%;
+    top: 40%;
     right: 0;
 }
 #arena[data-layout='nova'][data-number='8']>.player[data-position='2'] {
     left: auto;
-    top: 18%;
+    top: 10%;
     right: 0;
 }
 #arena[data-layout='nova'][data-number='8']>.player[data-position='3'] {
@@ -103,22 +103,22 @@
 }
 #arena[data-layout='nova'][data-number='8']>.player[data-position='6'] {
     left: 0;
-    top: 18%;
+    top: 10%;
 }
 #arena[data-layout='nova'][data-number='8']>.player[data-position='7'] {
     left: 0;
-    top: 45%;
+    top: 40%;
 }
 
 /*7人座, 2 player in center*/
 #arena[data-layout='nova'][data-number='7']>.player[data-position='1'] {
     left: auto;
-    top: 45%;
+    top: 40%;
     right: 0;
 }
 #arena[data-layout='nova'][data-number='7']>.player[data-position='2'] {
     left: auto;
-    top: 18%;
+    top: 10%;
     right: 0;
 }
 #arena[data-layout='nova'][data-number='7']>.player[data-position='3'] {
@@ -132,35 +132,35 @@
 }
 #arena[data-layout='nova'][data-number='7']>.player[data-position='5'] {
     left: 0;
-    top: 18%;
+    top: 10%;
 }
 #arena[data-layout='nova'][data-number='7']>.player[data-position='6'] {
     left: 0;
-    top: 45%;
+    top: 40%;
 }
 
-/*6人座, 1 player in center*/
+/*6人座, 3 player in center*/
 #arena[data-layout='nova'][data-number='6']>.player[data-position='1'] {
     left: auto;
-    top: 45%;
+    top: 18%;
     right: 0;
 }
 #arena[data-layout='nova'][data-number='6']>.player[data-position='2'] {
     left: auto;
-    top: 18%;
-    right: 0;
+    top: 0;
+    right: calc(30% - 60px);
 }
 #arena[data-layout='nova'][data-number='6']>.player[data-position='3'] {
     left: calc(50% - 60px);
     top: 0;
 }
 #arena[data-layout='nova'][data-number='6']>.player[data-position='4'] {
-    left: 0;
-    top: 18%;
+    left: calc(30% - 60px);
+    top: 0;
 }
 #arena[data-layout='nova'][data-number='6']>.player[data-position='5'] {
     left: 0;
-    top: 45%;
+    top: 18%;
 }
 
 
@@ -219,12 +219,12 @@
 /*10人座, 5 player in center*/
 #arena[data-layout='nova'][data-number='10']>.player[data-position='1'] {
     left: auto;
-    top: 45%;
+    top: 40%;
     right: 0;
 }
 #arena[data-layout='nova'][data-number='10']>.player[data-position='2'] {
     left: auto;
-    top: 18%;
+    top: 10%;
     right: 0;
 }
 #arena[data-layout='nova'][data-number='10']>.player[data-position='3'] {
@@ -251,22 +251,22 @@
 }
 #arena[data-layout='nova'][data-number='10']>.player[data-position='8'] {
     left: 0;
-    top: 18%;
+    top: 10%;
 }
 #arena[data-layout='nova'][data-number='10']>.player[data-position='9'] {
     left: 0;
-    top: 45%;
+    top: 40%;
 }
 
 /*9人座, 4 player in center*/
 #arena[data-layout='nova'][data-number='9']>.player[data-position='1'] {
     left: auto;
-    top: 45%;
+    top: 40%;
     right: 0;
 }
 #arena[data-layout='nova'][data-number='9']>.player[data-position='2'] {
     left: auto;
-    top: 18%;
+    top: 10%;
     right: 0;
 }
 #arena[data-layout='nova'][data-number='9']>.player[data-position='3'] {
@@ -289,9 +289,9 @@
 }
 #arena[data-layout='nova'][data-number='9']>.player[data-position='7'] {
     left: 0;
-    top: 18%;
+    top: 10%;
 }
 #arena[data-layout='nova'][data-number='9']>.player[data-position='8'] {
     left: 0;
-    top: 45%;
+    top: 40%;
 }

--- a/layout/long2/layout.css
+++ b/layout/long2/layout.css
@@ -440,6 +440,25 @@
     opacity: 1 !important;
 }
 
+/*--------位置(10人)------*/
+#arena[data-number='10']>.player[data-position='1']{top:calc(30% - 128px);left:calc(100% - 120px);}
+#arena[data-number='10']>.player[data-position='2']{top:calc(8% - 34px);left:calc(87.5% - 105px);}
+#arena[data-number='10']>.player[data-position='3']{top:0;left:calc(75% - 90px);}
+#arena[data-number='10']>.player[data-position='4']{top:0;left:calc(62.5% - 75px);}
+#arena[data-number='10']>.player[data-position='5']{top:0;left:calc(50% - 60px);}
+#arena[data-number='10']>.player[data-position='6']{top:0;left:calc(37.5% - 45px);}
+#arena[data-number='10']>.player[data-position='7']{top:0;left:calc(25% - 30px);}
+#arena[data-number='10']>.player[data-position='8']{top:calc(8% - 34px);left:calc(12.5% - 15px);}
+#arena[data-number='10']>.player[data-position='9']{top:calc(30% - 128px);left:0;}
+/*--------位置(9人)------*/
+#arena[data-number='9']>.player[data-position='1']{top:calc(30% - 128px);left:calc(100% - 120px);}
+#arena[data-number='9']>.player[data-position='2']{top:calc(8% - 34px);left:calc(85.8% - 102.6px);}
+#arena[data-number='9']>.player[data-position='3']{top:0;left:calc(71.5% - 85.5px);}
+#arena[data-number='9']>.player[data-position='4']{top:0;left:calc(57.2% - 68.4px);}
+#arena[data-number='9']>.player[data-position='5']{top:0;left:calc(42.9% - 51.3px);}
+#arena[data-number='9']>.player[data-position='6']{top:0;left:calc(28.6% - 34.2px);}
+#arena[data-number='9']>.player[data-position='7']{top:calc(8% - 34px);left:calc(14.3% - 17.1px);}
+#arena[data-number='9']>.player[data-position='8']{top:calc(30% - 128px);left:0;}
 /*--------位置(8人)------*/
 #arena[data-number='8']>.player[data-position='1']{top:calc(30% - 128px);left:calc(-300% / 94 + 4375% / 47 - 735px + 720px);}
 #arena[data-number='8']>.player[data-position='2']{top:calc(8% - 34px);left:calc(-300% / 94 + 3750% / 47 - 630px + 600px);}

--- a/layout/newlayout/global.css
+++ b/layout/newlayout/global.css
@@ -357,59 +357,6 @@
 }
 /*--------位置(n人)------*/
 
-/*--------位置(10人)------*/
-[data-number='10']>.player[data-position='1']{top:calc(200% / 3 - 160px);left:calc(100% - 150px);}
-[data-number='10']>.player[data-position='2']{top:calc(100% / 3 - 170px);left:calc(100% - 150px);}
-[data-number='10']>.player[data-position='3']{top:0;left:calc(80% - 75px);}
-[data-number='10']>.player[data-position='4']{top:0;left:calc(65% - 75px);}
-[data-number='10']>.player[data-position='5']{top:0;left:calc(50% - 75px);}
-[data-number='10']>.player[data-position='6']{top:0;left:calc(35% - 75px);}
-[data-number='10']>.player[data-position='7']{top:0;left:calc(20% - 75px);}
-[data-number='10']>.player[data-position='8']{top:calc(100% / 3 - 170px);left:0;}
-[data-number='10']>.player[data-position='9']{top:calc(200% / 3 - 160px);left:0;}
-[data-number='10']>.card[data-position='1']{top:calc(200% / 3 - 122px);left:calc(100% - 127px);}
-[data-number='10']>.card[data-position='2']{top:calc(100% / 3 - 132px);left:calc(100% - 127px);}
-[data-number='10']>.card[data-position='3']{top:38px;left:calc(75% - 89.5px);}
-[data-number='10']>.card[data-position='4']{top:38px;left:calc(50% - 52px);}
-[data-number='10']>.card[data-position='5']{top:38px;left:calc(25% - 14.5px);}
-[data-number='10']>.card[data-position='6']{top:38px;left:calc(25% - 14.5px);}
-[data-number='10']>.card[data-position='7']{top:38px;left:calc(25% - 14.5px);}
-[data-number='10']>.card[data-position='8']{top:calc(100% / 3 - 132px);left:23px;}
-[data-number='10']>.card[data-position='9']{top:calc(200% / 3 - 122px);left:23px;}
-[data-number='10']>.popup[data-position='1']{top:calc(200% / 3 - 150px);left:calc(100% - 186px);}
-[data-number='10']>.popup[data-position='2']{top:calc(100% / 3 - 160px);left:calc(100% - 186px);}
-[data-number='10']>.popup[data-position='3']{top:190px;left:calc(75% + 10.5px);}
-[data-number='10']>.popup[data-position='4']{top:190px;left:calc(50% - 61px);}
-[data-number='10']>.popup[data-position='5']{top:190px;left:calc(25% - 37.5px);}
-[data-number='10']>.popup[data-position='6']{top:190px;left:calc(25% - 37.5px);}
-[data-number='10']>.popup[data-position='7']{top:190px;left:calc(25% - 37.5px);}
-[data-number='10']>.popup[data-position='8']{top:calc(100% / 3 - 160px);left:160px;}
-[data-number='10']>.popup[data-position='9']{top:calc(200% / 3 - 150px);left:160px;}
-/*--------位置(9人)------*/
-[data-number='9']>.player[data-position='1']{top:calc(200% / 3 - 160px);left:calc(100% - 150px);}
-[data-number='9']>.player[data-position='2']{top:calc(100% / 3 - 170px);left:calc(100% - 150px);}
-[data-number='9']>.player[data-position='3']{top:0;left:calc(74% - 75px);}
-[data-number='9']>.player[data-position='4']{top:0;left:calc(58% - 75px);}
-[data-number='9']>.player[data-position='5']{top:0;left:calc(42% - 75px);}
-[data-number='9']>.player[data-position='6']{top:0;left:calc(26% - 75px);}
-[data-number='9']>.player[data-position='7']{top:calc(100% / 3 - 170px);left:0;}
-[data-number='9']>.player[data-position='8']{top:calc(200% / 3 - 160px);left:0;}
-[data-number='9']>.card[data-position='1']{top:calc(200% / 3 - 122px);left:calc(100% - 127px);}
-[data-number='9']>.card[data-position='2']{top:calc(100% / 3 - 132px);left:calc(100% - 127px);}
-[data-number='9']>.card[data-position='3']{top:38px;left:calc(75% - 89.5px);}
-[data-number='9']>.card[data-position='4']{top:38px;left:calc(50% - 52px);}
-[data-number='9']>.card[data-position='5']{top:38px;left:calc(25% - 14.5px);}
-[data-number='9']>.card[data-position='6']{top:38px;left:calc(25% - 14.5px);}
-[data-number='9']>.card[data-position='7']{top:calc(100% / 3 - 132px);left:23px;}
-[data-number='9']>.card[data-position='8']{top:calc(200% / 3 - 122px);left:23px;}
-[data-number='9']>.popup[data-position='1']{top:calc(200% / 3 - 150px);left:calc(100% - 186px);}
-[data-number='9']>.popup[data-position='2']{top:calc(100% / 3 - 160px);left:calc(100% - 186px);}
-[data-number='9']>.popup[data-position='3']{top:190px;left:calc(75% + 10.5px);}
-[data-number='9']>.popup[data-position='4']{top:190px;left:calc(50% - 61px);}
-[data-number='9']>.popup[data-position='5']{top:190px;left:calc(25% - 37.5px);}
-[data-number='9']>.popup[data-position='6']{top:190px;left:calc(25% - 37.5px);}
-[data-number='9']>.popup[data-position='7']{top:calc(100% / 3 - 160px);left:160px;}
-[data-number='9']>.popup[data-position='8']{top:calc(200% / 3 - 150px);left:160px;}
 /*--------位置(8人)------*/
 [data-number='8']>.player[data-position='1']{top:calc(200% / 3 - 160px);left:calc(100% - 150px);}
 [data-number='8']>.player[data-position='2']{top:calc(100% / 3 - 170px);left:calc(100% - 150px);}

--- a/layout/nova/layout.css
+++ b/layout/nova/layout.css
@@ -217,6 +217,25 @@
     border-radius:0px;
 }
 
+/*--------位置(10人)------*/
+[data-number='10']>.player[data-position='1']{top:calc(55% - 135px);left:calc(100% - 150px);}
+[data-number='10']>.player[data-position='2']{top:calc(10% - 50px);left:calc(100% - 150px);}
+[data-number='10']>.player[data-position='3']{top:0;left:calc(80% - 75px);}
+[data-number='10']>.player[data-position='4']{top:0;left:calc(65% - 75px);}
+[data-number='10']>.player[data-position='5']{top:0;left:calc(50% - 75px);}
+[data-number='10']>.player[data-position='6']{top:0;left:calc(35% - 75px);}
+[data-number='10']>.player[data-position='7']{top:0;left:calc(20% - 75px);}
+[data-number='10']>.player[data-position='8']{top:calc(10% - 50px);left:0;}
+[data-number='10']>.player[data-position='9']{top:calc(55% - 135px);left:0;}
+/*--------位置(9人)------*/
+[data-number='9']>.player[data-position='1']{top:calc(55% - 135px);left:calc(100% - 150px);}
+[data-number='9']>.player[data-position='2']{top:calc(10% - 50px);left:calc(100% - 150px);}
+[data-number='9']>.player[data-position='3']{top:0;left:calc(74% - 75px);}
+[data-number='9']>.player[data-position='4']{top:0;left:calc(58% - 75px);}
+[data-number='9']>.player[data-position='5']{top:0;left:calc(42% - 75px);}
+[data-number='9']>.player[data-position='6']{top:0;left:calc(26% - 75px);}
+[data-number='9']>.player[data-position='7']{top:calc(10% - 50px);left:0;}
+[data-number='9']>.player[data-position='8']{top:calc(55% - 135px);left:0;}
 /*--------位置(8人)------*/
 [data-number='8']>.player[data-position='1']{top:calc(55% - 135px);left:calc(100% - 150px);}
 [data-number='8']>.player[data-position='2']{top:calc(10% - 50px);left:calc(100% - 150px);}
@@ -259,6 +278,10 @@
 #arena[data-player_height_nova="default"]>.player[data-position='0']:not(.minskin){
     top: calc(100% - 236px);
 }
+[data-number='10'][data-player_height_nova="default"]>.player[data-position='1'],
+[data-number='10'][data-player_height_nova="default"]>.player[data-position='9'],
+[data-number='9'][data-player_height_nova="default"]>.player[data-position='1'],
+[data-number='9'][data-player_height_nova="default"]>.player[data-position='8'],
 [data-number='8'][data-player_height_nova="default"]>.player[data-position='1'],
 [data-number='8'][data-player_height_nova="default"]>.player[data-position='7'],
 [data-number='7'][data-player_height_nova="default"]>.player[data-position='1'],
@@ -304,6 +327,10 @@
 #arena[data-player_height_nova="long"]>.player[data-position='0']:not(.minskin){
     top: calc(100% - 250px);
 }
+[data-number='10'][data-player_height_nova="long"]>.player[data-position='1'],
+[data-number='10'][data-player_height_nova="long"]>.player[data-position='9'],
+[data-number='9'][data-player_height_nova="long"]>.player[data-position='1'],
+[data-number='9'][data-player_height_nova="long"]>.player[data-position='8'],
 [data-number='8'][data-player_height_nova="long"]>.player[data-position='1'],
 [data-number='8'][data-player_height_nova="long"]>.player[data-position='7'],
 [data-number='7'][data-player_height_nova="long"]>.player[data-position='1'],


### PR DESCRIPTION
Changes in this commit:
- improve sitting in extension/decadeUI/decadeLayout.css
- add 9/10 players support to: layout/long2/layout.css
- add 9/10 players support to: layout/nova/layout.css
- remove 9/10 players support from newlayout/global.css as they fit better in other files. (namely: nova layout uses: (extension/decadeUI/decadeLayout.css for decadeUI and layout/nova/layout.css for old UI); mobile layout and the rest fallback to: layout/long2/layout.css)